### PR TITLE
Set extension to be injected only on shadertoy page where it is useable

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,7 @@
     "homepage_url": "https://github.com/tdhooper/shadertoy-frame-exporter",
     "content_scripts": [
         {
-            "matches": ["*://*.shadertoy.com/*"],
+            "matches": ["*://*.shadertoy.com/view/*"],
             "js": ["inject.js"],
             "css": ["styles.css"]
         }


### PR DESCRIPTION
Extensions throws errors visible in console on any other shadertoy page