### PR TITLE
Add controls to new shader page

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,7 @@
     "homepage_url": "https://github.com/tdhooper/shadertoy-frame-exporter",
     "content_scripts": [
         {
-            "matches": ["https://www.shadertoy.com/view/*"],
+            "matches": ["https://www.shadertoy.com/view/*", "https://www.shadertoy.com/new"],
             "js": [
                 "main.js",
                 "lib/FileSaver-2.0.4.min.js"


### PR DESCRIPTION
I'm not very familiar with the Shadertoy site code, but this page looks the same as the browse pages. Tested with a pasted in shader and the extension seemed to export frames as expected. Didn't test further since I have what I need and figured I'd throw this your way and see if it's useful as is.

Thanks for the handy extension either way.